### PR TITLE
Update go package name

### DIFF
--- a/10-main-to-container/golang/main.go
+++ b/10-main-to-container/golang/main.go
@@ -1,4 +1,4 @@
-package golang
+package main
 
 import (
 	"fmt"


### PR DESCRIPTION
`go run` requires package to be `main` package by default